### PR TITLE
Workaround for posting new comment for azure blob

### DIFF
--- a/action.py
+++ b/action.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 NOTE = "\n\n*Note: This comment is automatically posted by the " \
-       "Documentation Publishing GitHub Action.*"
+       "Documentation Publish GitHub Action.*"
 PREFIX = "You can find the documentation preview for this PR at this " \
          "<a href='{}'>link</a>. It will be updated about 10 minutes after " \
          "the documentation build succeeds."


### PR DESCRIPTION
This is workaround for fixing docpublish url. Something else should also work.